### PR TITLE
fix: update api url and add reverse comand

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "reverse": "adb reverse tcp:9090 tcp:9090",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",

--- a/mobile/src/services/api.js
+++ b/mobile/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://10.0.2.2:3333',
+  baseURL: 'http://localhost:3333',
 });
 
 export default api;


### PR DESCRIPTION
Olá meu caro isso acontece porque o emulador do Android possui uma rede interna para o ip 10.2.2.2, já o IOS é um simulador e possui acesso direto ao localhost, aconselho a trocar a url para localhost e rodar o comando "yarn reverse" ou "npm reverse", que criei no package.json, isso já resolveria o problema no Android e funcionaria normal no IOS.

Boa Sorte.